### PR TITLE
Use abstract ‘Array’ for javascript types impl.

### DIFF
--- a/common/src/main/java/com/github/cao/awa/conium/bedrock/entity/player/delegate/BedrockPlayerDelegate.kt
+++ b/common/src/main/java/com/github/cao/awa/conium/bedrock/entity/player/delegate/BedrockPlayerDelegate.kt
@@ -4,12 +4,15 @@ import com.github.cao.awa.conium.annotation.bedrock.BedrockScriptApi
 import com.github.cao.awa.conium.annotation.bedrock.BedrockScriptApiFacade
 import com.github.cao.awa.conium.bedrock.entity.player.BedrockPlayer
 import com.github.cao.awa.conium.bedrock.entity.player.bedrockPlayer
+import com.github.cao.awa.conium.script.javascript.std.collection.array.Array
 import net.minecraft.server.MinecraftServer
 
 @BedrockScriptApi
 @BedrockScriptApiFacade("Player[]")
-class BedrockPlayerDelegate(private val delegate: MinecraftServer) {
-    operator fun get(index: Int): BedrockPlayer {
-        return this.delegate.playerManager.playerList[index].bedrockPlayer
+class BedrockPlayerDelegate(
+    private val server: MinecraftServer
+): Array<BedrockPlayer>() {
+    override operator fun get(index: Int): BedrockPlayer {
+        return this.server.playerManager.playerList[index].bedrockPlayer
     }
 }

--- a/common/src/main/java/com/github/cao/awa/conium/script/javascript/std/collection/array/Array.kt
+++ b/common/src/main/java/com/github/cao/awa/conium/script/javascript/std/collection/array/Array.kt
@@ -1,0 +1,5 @@
+package com.github.cao.awa.conium.script.javascript.std.collection.array
+
+abstract class Array<T> {
+    abstract operator fun get(index: Int): T
+}


### PR DESCRIPTION
Use abstract ‘Array’ for javascript types impl.